### PR TITLE
Refactor to reflect new location server API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,39 +1,3 @@
-
-Skip to content
-This repository
-
-    Pull requests
-    Issues
-    Gist
-
-    @aguestuser
-
-1,219
-26,125
-
-    9,564
-
-github/gitignore
-
-gitignore/Node.gitignore
-@Gouthamve Gouthamve on Apr 30 Fix typo from node_modules to node-modules
-
-17 contributors
-@stuartpb
-@arcresu
-@cheddar
-@Gouthamve
-@iamsebastian
-@joreyaesh
-@jenrik
-@izuzak
-@kerimdzhanov
-@peat
-@rsolomo
-@indexzero
-@sroberts
-@aoberoi
-@pronebird
 logs
 *.log
 pids

--- a/modules/api.js
+++ b/modules/api.js
@@ -2,13 +2,12 @@ const http = require('superagent');
 
 const api = {};
 
-api.url = "https://whereat-server.herokuapp.com";
+api.url = process.NODE_ENV === 'dev' ?
+  "https://dev-api.whereat.com" :
+  "https://api.whereat.com";
 
-// (Array[LocationInitPojo]) -> Promise[Array[LocationResponse]]
-api.init = (reqs) => Promise.all(reqs.map(req => api.post('init', req)));
-
-// (Array[LocationRefreshPojo]) -> Promise[Array[LocationResponse]]
-api.refresh = (reqs) => Promise.all(reqs.map(req => api.post('refresh', req)));
+// (Array[LocationUpdatePojo]) -> Promise[Array[LocationResponse]]
+api.update = (reqs) => Promise.all(reqs.map(req => api.post('update', req)));
 
 // (Array[String]) -> Promise[Array[String]]
 api.remove = (ids) => Promise.all(ids.map(id => api.post('remove', id)));

--- a/simulate.js
+++ b/simulate.js
@@ -7,64 +7,56 @@ const _ = require('lodash');
 const reqInterval = 4.5;
 const tnInterval = .5;
 
+/**
+ * usage:
+ * $ node simulate nyseConverge 3
+ * $ node simulate nyseConverge 50
+ */
+
 
 // (String, Number) => Unit
 const main = (specPath, mult) => {
 
   const tn = telnet.getInstance();
   const specs = require(`./data/${specPath}`);
-  const uuids = parse.getUuids(specs, mult);
+  const uids = parse.getUuids(specs, mult);
 
   telnet.connect(tn)
-    .then(res => api.erase())
-    .then(res => init(tn, specs, uuids, mult))
-    .then(res => refresh(tn, specs, uuids, mult))
-    .then(res => telnet.close(tn))
-    .then(res => process.exit())
+    .then(() => api.erase())
+    .then(res => console.log(res.body.msg))
+    .then(() => updateMany(tn, specs, uids, mult))
+    .then(() => telnet.close(tn))
+    .then(() => process.exit())
     .catch(err => {
       console.error(JSON.stringify(err, null, 2));
       process.exit();
     });
-
-};
-
-// (TelnetClient, Number, LocationSpecs) -> Promise[Unit]
-const init = (tn, specs, uuids, mult) => {
-  const reqs = parse.initRequests(specs, uuids, mult);
-  return api.init(reqs)
-    .then(res => console.log("Received API responses to `locations/init`: \n", res))
-    .then(res => wait(tnInterval))
-    .then(res => {
-      console.log(`Sending telnet cmd: ${specs.telnet[0]}`);
-      tn.exec(specs.telnet[0], console.log);
-    });
 };
 
 // (TelnetClient, Number, LocationSpec) -> Promise[Unit]
-const refresh = (tn, specs, uuids, mult) => {
-  const reqGroups = parse.refreshRequests(specs, uuids, mult);
-  return reqGroups.reduce(
+const updateMany = (tn, specs, uids, mult) => {
+  const reqLists = parse.updateRequests(specs, uids, mult);
+  return reqLists.reduce(
     (promiseSeq, reqs, i) => promiseSeq
-      .then(res => wait(reqInterval))
-      .then(res => refreshOne(reqs, tn, specs.telnet[i + 1]))
-    , Promise.resolve()
-  );
+      .then(() => wait(reqInterval))
+      .then(() => updateOne(reqs, tn, specs.telnet[i + 1]))
+      , Promise.resolve());
 };
+
+// (Array[LocationRefreshRequest], TelnetConnection, String) -> Promise[Unit]
+const updateOne = (reqs, tn, cmd) =>(
+  api.update(reqs)
+    .then(res => console.log("Received API responses to `locations/refresh`: \n", res))
+    .then(() => wait(tnInterval))
+    .then(() => {
+      console.log(`Sending telnet cmd: ${cmd}`);
+      tn.exec(cmd, console.log);
+    }));
 
 // (LocationSpec) -> Promise[Unit]
 const remove = (specs) => (
   api.remove(parse.ids(specs))
     .then(res => console.log("Received API response to removal requests: \n", res))
 );
-
-// (Array[LocationRefreshRequest], TelnetConnection, String) -> Promise[Unit]
-const refreshOne = (reqs, tn, cmd) =>
-  api.refresh(reqs)
-    .then(res => console.log("Received API responses to `locations/refresh`: \n", res))
-    .then(res => wait(tnInterval))
-    .then(res => {
-      console.log(`Sending telnet cmd: ${cmd}`);
-      tn.exec(cmd, console.log);
-    });
 
 main(process.argv[2], process.argv[3]);

--- a/test/parse.spec.js
+++ b/test/parse.spec.js
@@ -1,7 +1,9 @@
 const chai = require('chai');
 const should = chai.should();
 const parse = require('../modules/parse');
-const { lSpecs, initRequests, refreshRequests, ids } = require('./samples');
+const { lSpecs, updateRequests, initRequests, refreshRequests, ids } = require('./samples');
+const { max, floor } = require('lodash');
+const { abs } = Math;
 
 describe('parse module', () => {
 
@@ -12,56 +14,52 @@ describe('parse module', () => {
     });
   });
 
-  describe('#initRequests', () => {
+  describe('#updateRequests', () => {
 
     describe('with a multiplier of 1', () => {
 
-      it('wraps each LatLon in an #init request, maintaining its value', () => {
+      it('wraps each LatLon in an #update request, maintaining its value', () => {
         const ids = parse.getUuids(lSpecs, 1);
-        parse.initRequests(lSpecs, ids, 1).should.eql(initRequests);
+        parse.updateRequests(lSpecs, ids, 1).should.eql(updateRequests);
       });
     });
 
     describe('with a multiplier of 3', () => {
 
-      it('wraps n LatLons in requests, randomly offsetting the value of each', () => {
+      it('generates 3 requests for each LatLon, offsetting the value of last 2', () => {
         const ids = parse.getUuids(lSpecs, 3);
-        const res = parse.initRequests(lSpecs, ids, 3);
-        console.log(">>>>INIT REQUESTS * 3");
-        console.log(JSON.stringify(res, null, 2));
-        res.length.should.equal(initRequests.length * 3);
-        //max(lats.map(l => abs(orig - l))).should.beLessThan(parse.variance)
-      });
-    });
-  });
+        const reqLists = parse.updateRequests(lSpecs, ids, 3);
 
-  describe('#refreshRequests', () => {
+        reqLists.length.should.equal(updateRequests.length);
 
-    describe('with a multiplier of 1', () => {
+        reqLists.forEach((reqs, i) => {
+          reqs.length.should.equal(6);
 
-      it('wraps each LatLon in a #refresh request, maintaining its value', () => {
-        const ids = parse.getUuids(lSpecs, 1);
-        parse.refreshRequests(lSpecs, ids, 1).should.eql(refreshRequests);
-      });
+          reqs.forEach((req, j) => {
+            req.hasOwnProperty('lastPing').should.beTrue;
+            req.hasOwnProperty('location').should.beTrue;
+            req.lastPing.should.equal(0);
 
-      describe('with a multiplier of 3', () => {
+            switch(j){
+            case 0:
+              req.location.id.should.equal(lSpecs.http[0].id);
+              break;
+            case 3:
+              req.location.id.should.equal(lSpecs.http[1].id);
+              break;
+            default:
+              req.location.id.should.equal(ids[j-1]);
+              break;
+            }
 
-        it('wraps n LatLons in requests, randomly offsetting the value of each', () => {
-          const ids = parse.getUuids(lSpecs, 3);
-          const res = parse.refreshRequests(lSpecs, ids, 3);
-          console.log(">>>>REFRESH REQUESTS * 3");
-          console.log(JSON.stringify(res, null, 2));
-          res.length.should.equal(refreshRequests.length);
-          //max(lats.map(l => abs(orig - l))).should.beLessThan(parse.variance)
+            abs(req.location.lat - updateRequests[i][floor(j/3)].location.lat)
+              .should.be.below(parse.variance);
+            abs(req.location.lon - updateRequests[i][floor(j/3)].location.lon)
+              .should.be.below(parse.variance);
+            req.location.time.should.equal(lSpecs.time);
+          });
         });
       });
-    });
-  });
-
-  describe('#ids', () => {
-
-    it('parses an array of ids of simulated external users', () => {
-      parse.ids(lSpecs).should.eql(ids);
     });
   });
 });

--- a/test/samples.js
+++ b/test/samples.js
@@ -36,39 +36,28 @@ samples.ids = [
   "75782cd4-1a42-4af1-9130-05c63b2aa9fb"
 ];
 
-samples.initRequests = [{
-  id: "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
-  lat: 40.704715,
-  lon: -74.013685,
-  time: 2505606400000
-}, {
-  id: "75782cd4-1a42-4af1-9130-05c63b2aa9fb",
-  lat: 40.703084,
-  lon: -74.010126,
-  time: 2505606400000
-}];
 
-samples.initResponses = [
-  [{
-    "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
-    "lat": 40.704715,
-    "lon": -74.013685,
-    "time": 2505606400000
-  }],
-  [{
-    "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
-    "lat": 40.704715,
-    "lon": -74.013685,
-    "time": 2505606400000
-  }, {
-    "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fb",
-    "lat": 40.703084,
-    "lon": -74.010126,
-    "time": 2505606400000
-  }]
-];
-
-samples.refreshRequests = [
+samples.updateRequests = [
+  [
+    {
+      lastPing: 0,
+      location: {
+        id: "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
+        lat: 40.704715,
+        lon: -74.013685,
+        time: 2505606400000
+      }
+    },
+    {
+      lastPing: 0,
+      location: {
+        id: "75782cd4-1a42-4af1-9130-05c63b2aa9fb",
+        lat: 40.703084,
+        lon: -74.010126,
+        time: 2505606400000
+      }
+    }
+  ],
   [
     {
       lastPing: 0,
@@ -131,178 +120,24 @@ samples.refreshRequests = [
   ]
 ];
 
-samples.refreshRequestsMult3 =
-[
-  [
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
-        "lat": 40.705007,
-        "lon": -74.012537,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "887da326-7c89-46bd-a132-bd74a3b3fce80",
-        "lat": 40.705243,
-        "lon": -74.012989,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "8e3ae8b5-79a5-41fa-a9cf-4bd674115c8b0",
-        "lat": 40.70542,
-        "lon": -74.012238,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fb",
-        "lat": 40.704092,
-        "lon": -74.008989,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "887da326-7c89-46bd-a132-bd74a3b3fce83",
-        "lat": 40.703768,
-        "lon": -74.008922,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "8e3ae8b5-79a5-41fa-a9cf-4bd674115c8b3",
-        "lat": 40.70442,
-        "lon": -74.008501,
-        "time": 2505606400000
-      }
-    }
-  ],
-  [
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
-        "lat": 40.705731,
-        "lon": -74.011443,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "887da326-7c89-46bd-a132-bd74a3b3fce80",
-        "lat": 40.705631,
-        "lon": -74.011158,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "8e3ae8b5-79a5-41fa-a9cf-4bd674115c8b0",
-        "lat": 40.705686,
-        "lon": -74.011742,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fb",
-        "lat": 40.705264,
-        "lon": -74.010029,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "887da326-7c89-46bd-a132-bd74a3b3fce83",
-        "lat": 40.705317,
-        "lon": -74.010346,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "8e3ae8b5-79a5-41fa-a9cf-4bd674115c8b3",
-        "lat": 40.705711,
-        "lon": -74.010229,
-        "time": 2505606400000
-      }
-    }
-  ],
-  [
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
-        "lat": 40.706886,
-        "lon": -74.010853,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "887da326-7c89-46bd-a132-bd74a3b3fce80",
-        "lat": 40.706969,
-        "lon": -74.010887,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "8e3ae8b5-79a5-41fa-a9cf-4bd674115c8b0",
-        "lat": 40.707062,
-        "lon": -74.010588,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fb",
-        "lat": 40.706638,
-        "lon": -74.011006,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "887da326-7c89-46bd-a132-bd74a3b3fce83",
-        "lat": 40.706346,
-        "lon": -74.011174,
-        "time": 2505606400000
-      }
-    },
-    {
-      "lastPing": 0,
-      "location": {
-        "id": "8e3ae8b5-79a5-41fa-a9cf-4bd674115c8b3",
-        "lat": 40.70692,
-        "lon": -74.011299,
-        "time": 2505606400000
-      }
-    }
-  ]
+samples.initResponses = [
+  [{
+    "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
+    "lat": 40.704715,
+    "lon": -74.013685,
+    "time": 2505606400000
+  }],
+  [{
+    "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fa",
+    "lat": 40.704715,
+    "lon": -74.013685,
+    "time": 2505606400000
+  }, {
+    "id": "75782cd4-1a42-4af1-9130-05c63b2aa9fb",
+    "lat": 40.703084,
+    "lon": -74.010126,
+    "time": 2505606400000
+  }]
 ];
-
-
 
 module.exports = samples;


### PR DESCRIPTION
- restrict api module to only use #update endpoint instead of #init, #refresh
  (reflecting changes to API server)
- use URL for staging server API instead of prod
- add tests for randomized pins
  - verify shape of pins, collection of pins correct
  - verify type and values of static fields
  - verify randomized fields within desired variance
