### PR TITLE
Fix babel config, api URL

### DIFF
--- a/modules/api.js
+++ b/modules/api.js
@@ -3,8 +3,8 @@ const http = require('superagent');
 const api = {};
 
 api.url = process.NODE_ENV === 'dev' ?
-  "https://dev-api.whereat.com" :
-  "https://api.whereat.com";
+  "https://dev-api.whereat.io" :
+  "https://api.whereat.io";
 
 // (Array[LocationUpdatePojo]) -> Promise[Array[LocationResponse]]
 api.update = (reqs) => Promise.all(reqs.map(req => api.post('update', req)));

--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
   "description": "grab bag of scripts for simulating use of whereat",
   "main": "main.js",
   "dependencies": {
-    "babel": "^5.6.23",
-    "babel-runtime": "^5.7.0",
+    "babel": "^6.3.26",
+    "babel-cli": "^6.4.0",
+    "babel-preset-es2015": "^6.3.13",
     "lodash": "^3.10.0",
     "node-uuid": "^1.4.3",
     "superagent": "^1.2.0",
     "telnet-client": "^0.1.0"
   },
   "devDependencies": {
+    "babel-register": "^6.4.3",
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
     "grunt": "^0.4.5",


### PR DESCRIPTION
- In preparation for onboarding, fix dev environment, namely:
  - update babel presets so it works from npm (don't depend on global settings)
  - fix typo in whereat api url
